### PR TITLE
Add OpenSearch index mapping and graph API stub

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,14 @@
 from flask import Flask
 
+from app.blueprints.api import api_bp
+
+
 def create_app() -> Flask:
     app = Flask(__name__)
+    app.register_blueprint(api_bp, url_prefix="/api")
 
-    @app.route('/health')
+    @app.route("/health")
     def health() -> tuple[str, int]:
-        return 'ok', 200
+        return "ok", 200
 
     return app

--- a/app/blueprints/api/__init__.py
+++ b/app/blueprints/api/__init__.py
@@ -1,0 +1,11 @@
+from flask import Blueprint
+
+from .graph import graph
+
+
+api_bp = Blueprint("api", __name__)
+api_bp.add_url_rule("/graph", view_func=graph)
+
+
+__all__ = ["api_bp"]
+

--- a/app/blueprints/api/graph.py
+++ b/app/blueprints/api/graph.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class GraphNode(BaseModel):
+    id: str
+    title: str
+    value: int
+
+
+class GraphEdge(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    from_: str = Field(..., alias="from")
+    to: str
+    weight: float
+
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+
+
+def graph() -> tuple[dict, int]:
+    sample = GraphResponse(
+        nodes=[GraphNode(id="uuid1", title="...", value=93)],
+        edges=[GraphEdge(from_="uuid1", to="uuid2", weight=0.8)],
+    )
+    return sample.model_dump(by_alias=True), 200
+
+
+__all__ = ["GraphNode", "GraphEdge", "GraphResponse", "graph"]
+

--- a/app/blueprints/api/graph_example.json
+++ b/app/blueprints/api/graph_example.json
@@ -1,0 +1,9 @@
+{
+  "nodes": [
+    {"id": "uuid1", "title": "...", "value": 93}
+  ],
+  "edges": [
+    {"from": "uuid1", "to": "uuid2", "weight": 0.8}
+  ]
+}
+

--- a/app/services/search/__init__.py
+++ b/app/services/search/__init__.py
@@ -1,0 +1,4 @@
+from .index import ITEMS_INDEX, create_items_index, items_index_body
+
+__all__ = ["ITEMS_INDEX", "create_items_index", "items_index_body"]
+

--- a/app/services/search/index.py
+++ b/app/services/search/index.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from opensearchpy import OpenSearch
+
+
+ITEMS_INDEX = "items"
+
+
+def items_index_body(*, shards: int = 1, replicas: int = 0) -> dict:
+    """Return the index creation body for the items index."""
+
+    return {
+        "settings": {"number_of_shards": shards, "number_of_replicas": replicas},
+        "mappings": {
+            "dynamic_templates": [
+                {
+                    "gematria_values_ints": {
+                        "path_match": "gematria_values.*",
+                        "mapping": {"type": "integer"},
+                    }
+                }
+            ],
+            "properties": {
+                "id": {"type": "keyword"},
+                "source": {"type": "keyword"},
+                "published_at": {"type": "date"},
+                "lang": {"type": "keyword"},
+                "title": {"type": "text", "analyzer": "english"},
+                "url": {"type": "keyword"},
+                "gematria_values": {"type": "object"},
+                "tags": {"type": "keyword"},
+                "author": {"type": "keyword"},
+            },
+        },
+    }
+
+
+def create_items_index(
+    client: OpenSearch, *, index_name: str = ITEMS_INDEX, shards: int = 1, replicas: int = 0
+) -> None:
+    """Create the items index if it does not already exist."""
+
+    body = items_index_body(shards=shards, replicas=replicas)
+    if not client.indices.exists(index=index_name):
+        client.indices.create(index=index_name, body=body)
+
+
+__all__ = ["ITEMS_INDEX", "items_index_body", "create_items_index"]
+

--- a/deploy/opensearch.json
+++ b/deploy/opensearch.json
@@ -3,5 +3,25 @@
     "number_of_shards": 1,
     "number_of_replicas": 0
   },
-  "mappings": {}
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "gematria_values_ints": {
+          "path_match": "gematria_values.*",
+          "mapping": {"type": "integer"}
+        }
+      }
+    ],
+    "properties": {
+      "id": {"type": "keyword"},
+      "source": {"type": "keyword"},
+      "published_at": {"type": "date"},
+      "lang": {"type": "keyword"},
+      "title": {"type": "text", "analyzer": "english"},
+      "url": {"type": "keyword"},
+      "gematria_values": {"type": "object"},
+      "tags": {"type": "keyword"},
+      "author": {"type": "keyword"}
+    }
+  }
 }

--- a/tests/test_api_graph.py
+++ b/tests/test_api_graph.py
@@ -1,0 +1,12 @@
+from app import create_app
+from app.blueprints.api.graph import GraphResponse
+
+
+def test_graph_endpoint_returns_sample():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/api/graph")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    GraphResponse(**data)
+    assert data["nodes"][0]["id"] == "uuid1"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,12 @@
+from app.services.search import items_index_body
+
+
+def test_items_index_body_structure():
+    body = items_index_body()
+    assert body["settings"] == {"number_of_shards": 1, "number_of_replicas": 0}
+    props = body["mappings"]["properties"]
+    assert props["id"]["type"] == "keyword"
+    assert props["title"]["analyzer"] == "english"
+    assert props["published_at"]["type"] == "date"
+    templates = body["mappings"]["dynamic_templates"]
+    assert templates[0]["gematria_values_ints"]["path_match"] == "gematria_values.*"


### PR DESCRIPTION
## Summary
- define items index mapping and helper to create OpenSearch index
- expose /api/graph endpoint with pydantic response models
- add tests for index mapping and graph endpoint

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f94b3b04833094f67b85d1d4f45b