### PR TITLE
Add OpenSearch search response schema and example

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -112,13 +112,13 @@ Akzeptanzkriterien: Migration läuft ohne Fehler, Foreign Keys korrekt, pytest -
 
 2) OpenSearch-Index & Mapping
 
-[ ] Index items anlegen mit Mapping:
+[x] Index items anlegen mit Mapping:
 
 Felder: id (keyword), source (keyword), published_at (date), lang (keyword), title (text, analyzer english), url (keyword),
 gematria_values (object per scheme → integer), tags (keyword), author (keyword)
 
 
-[ ] Shards/Replicas: 1/0 lokal; prod 3/1
+[x] Shards/Replicas: 1/0 lokal; prod 3/1
 
 [ ] Aggregationen testen: by scheme, value, source, hour_of_day
 
@@ -428,7 +428,7 @@ fmt: black .
   "buckets": {"by_source":{"Reuters":44}}
 }
 
-[ ] GET /api/graph
+[x] GET /api/graph
 
 {"nodes":[{"id":"uuid1","title":"...","value":93}], "edges":[{"from":"uuid1","to":"uuid2","weight":0.8}]}
 

--- a/app/services/search/__init__.py
+++ b/app/services/search/__init__.py
@@ -1,4 +1,11 @@
 from .index import ITEMS_INDEX, create_items_index, items_index_body
+from .schemas import ItemDocument, Buckets, SearchResponse
 
-__all__ = ["ITEMS_INDEX", "create_items_index", "items_index_body"]
-
+__all__ = [
+    "ITEMS_INDEX",
+    "create_items_index",
+    "items_index_body",
+    "ItemDocument",
+    "Buckets",
+    "SearchResponse",
+]

--- a/app/services/search/schemas.py
+++ b/app/services/search/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class ItemDocument(BaseModel):
+    id: str
+    source: str
+    published_at: datetime
+    lang: str | None = None
+    title: str
+    url: str
+    gematria_values: dict[str, int] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    author: str | None = None
+
+
+class Buckets(BaseModel):
+    by_source: dict[str, int] = Field(default_factory=dict)
+
+
+class SearchResponse(BaseModel):
+    items: list[ItemDocument]
+    buckets: Buckets | None = None
+
+
+__all__ = ["ItemDocument", "Buckets", "SearchResponse"]

--- a/app/services/search/search_response_example.json
+++ b/app/services/search/search_response_example.json
@@ -1,0 +1,26 @@
+{
+  "items": [
+    {
+      "id": "uuid1",
+      "title": "Market jitters as markets await Fed",
+      "url": "https://example.com/article",
+      "source": "Reuters",
+      "published_at": "2025-09-12T14:05:00Z",
+      "gematria_values": {
+        "ordinal": 93,
+        "reduction": 39
+      },
+      "tags": [
+        "markets",
+        "fed"
+      ],
+      "author": "Jane Doe",
+      "lang": "en"
+    }
+  ],
+  "buckets": {
+    "by_source": {
+      "Reuters": 44
+    }
+  }
+}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,7 @@
-from app.services.search import items_index_body
+from pathlib import Path
+import json
+
+from app.services.search import items_index_body, SearchResponse
 
 
 def test_items_index_body_structure():
@@ -10,3 +13,10 @@ def test_items_index_body_structure():
     assert props["published_at"]["type"] == "date"
     templates = body["mappings"]["dynamic_templates"]
     assert templates[0]["gematria_values_ints"]["path_match"] == "gematria_values.*"
+
+
+def test_search_response_example_validates():
+    example_path = Path("app/services/search/search_response_example.json")
+    data = json.loads(example_path.read_text())
+    resp = SearchResponse(**data)
+    assert resp.items[0].source == "Reuters"


### PR DESCRIPTION
## Summary
- add Pydantic models for OpenSearch item search responses
- include sample search response JSON and expose in search package
- test that sample response validates and mark related tasks complete

## Testing
- `ruff check app/services/search/schemas.py tests/test_search.py app/services/search/__init__.py`
- `pytest tests/test_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5faa97d488330b0f6a0422a4502b1