### PR TITLE
Add gematria computation engine with tests

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -130,22 +130,22 @@ DoD: make seed-os erzeugt Index, GET /api/search liefert Aggregationen.
 
 3) Gematria-Engine (Services)
 
-[ ] Schemes definieren (app/services/gematria/schemes.py)
+[x] Schemes definieren (app/services/gematria/schemes.py)
 
 ordinal, reduction (Pythagorean), reverse, reverse_reduction
 
 optional: ALW/ALB/KFW als JSON-Mapping
 
 
-[ ] Normalizer (ignore_pattern = r'[^A-Z]', konfigurierbar)
+[x] Normalizer (ignore_pattern = r'[^A-Z]', konfigurierbar)
 
-[ ] API
+[x] API
 
 compute_all(text:str, schemes:list[str]) -> dict[str,int]
 digital_root(n:int) -> int
 factor_signature(n:int) -> dict[int,int]
 
-[ ] Unit-Tests: bekannte Beispiele, Edge Cases (Zahlen, Emojis, Unicode)
+[x] Unit-Tests: bekannte Beispiele, Edge Cases (Zahlen, Emojis, Unicode)
 
 
 DoD: 100% Tests für compute_all, Benchmarks (<0.2ms/Headline avg. lokal).

--- a/app/services/gematria/__init__.py
+++ b/app/services/gematria/__init__.py
@@ -1,0 +1,57 @@
+"""Gematria computation utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable
+
+from .schemes import SCHEMES
+
+
+def normalize(text: str, *, ignore_pattern: str = r"[^A-Z]") -> str:
+    """Normalize text by uppercasing and removing characters matching ignore_pattern."""
+    pattern = re.compile(ignore_pattern)
+    return pattern.sub("", text.upper())
+
+
+def compute_all(
+    text: str,
+    schemes: Iterable[str] | None = None,
+    *,
+    ignore_pattern: str = r"[^A-Z]",
+) -> Dict[str, int]:
+    """Compute gematria values for ``text`` across ``schemes``."""
+    if schemes is None:
+        schemes = SCHEMES.keys()
+    normalized = normalize(text, ignore_pattern=ignore_pattern)
+    results: Dict[str, int] = {}
+    for name in schemes:
+        mapping = SCHEMES[name]
+        results[name] = sum(mapping.get(ch, 0) for ch in normalized)
+    return results
+
+
+def digital_root(n: int) -> int:
+    """Return the digital root of ``n`` (iterative sum of digits)."""
+    n = abs(n)
+    while n >= 10:
+        n = sum(int(d) for d in str(n))
+    return n
+
+
+def factor_signature(n: int) -> Dict[int, int]:
+    """Return the prime factorization of ``n`` as a mapping prime→count."""
+    n = abs(n)
+    factors: Dict[int, int] = {}
+    divisor = 2
+    while divisor * divisor <= n:
+        while n % divisor == 0:
+            factors[divisor] = factors.get(divisor, 0) + 1
+            n //= divisor
+        divisor += 1
+    if n > 1:
+        factors[n] = factors.get(n, 0) + 1
+    return factors
+
+
+__all__ = ["SCHEMES", "normalize", "compute_all", "digital_root", "factor_signature"]

--- a/app/services/gematria/schemes.py
+++ b/app/services/gematria/schemes.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Gematria letter mappings for various schemes."""
+
+from typing import Dict
+
+
+def _build_ordinal() -> Dict[str, int]:
+    return {chr(ord("A") + i): i + 1 for i in range(26)}
+
+
+def _build_reduction() -> Dict[str, int]:
+    ordinal = _build_ordinal()
+    return {ch: (val - 1) % 9 + 1 for ch, val in ordinal.items()}
+
+
+def _build_reverse() -> Dict[str, int]:
+    return {chr(ord("Z") - i): i + 1 for i in range(26)}
+
+
+def _build_reverse_reduction() -> Dict[str, int]:
+    reverse = _build_reverse()
+    return {ch: (val - 1) % 9 + 1 for ch, val in reverse.items()}
+
+
+SCHEMES: Dict[str, Dict[str, int]] = {
+    "ordinal": _build_ordinal(),
+    "reduction": _build_reduction(),
+    "reverse": _build_reverse(),
+    "reverse_reduction": _build_reverse_reduction(),
+}
+
+
+__all__ = ["SCHEMES"]

--- a/tests/test_gematria.py
+++ b/tests/test_gematria.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.services.gematria import compute_all, digital_root, factor_signature
+
+
+def test_compute_all_known_examples():
+    text = "CAT"
+    result = compute_all(text, ["ordinal", "reduction", "reverse", "reverse_reduction"])
+    assert result == {
+        "ordinal": 24,
+        "reduction": 6,
+        "reverse": 57,
+        "reverse_reduction": 21,
+    }
+
+
+def test_compute_all_ignores_non_letters():
+    text = "C4T 🎉"
+    result = compute_all(text, ["ordinal", "reduction"])
+    assert result == {"ordinal": 23, "reduction": 5}
+
+
+def test_compute_all_unicode_normalization():
+    text = "Café"
+    result = compute_all(text, ["ordinal"])
+    assert result == {"ordinal": 10}
+
+
+def test_compute_all_empty_string():
+    assert compute_all("", ["ordinal"]) == {"ordinal": 0}
+
+
+def test_digital_root():
+    assert digital_root(942) == 6
+    assert digital_root(0) == 0
+
+
+def test_factor_signature():
+    assert factor_signature(84) == {2: 2, 3: 1, 7: 1}
+    assert factor_signature(13) == {13: 1}
+    assert factor_signature(1) == {}


### PR DESCRIPTION
## Summary
- implement gematria service with multiple schemes and normalization
- add digital root and prime factorization helpers
- cover gematria engine with unit tests and update task checklist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5fbe326c48330a3545a093f9dcaba