### PR TITLE
Add observability logging and Prometheus metrics

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -304,13 +304,13 @@ DoD: Rollen prüfen; Admin-only Routen geschützt; Security-Header via Nginx.
 
 9) Observability & Logs
 
-[ ] Structured Logging (JSON) für Web & Worker
+[x] Structured Logging (JSON) für Web & Worker
 
-[ ] Prometheus-Metrics (Requests, Task-Duration, Queue-Depth)
+[x] Prometheus-Metrics (Requests, Task-Duration, Queue-Depth)
 
-[ ] Healthchecks /health, /ready
+[x] Healthchecks /health, /ready
 
-[ ] Sentry (optional) DSN in .env
+[x] Sentry (optional) DSN in .env
 
 
 DoD: curl /metrics zeigt Counter/Gauges; Task-Laufzeiten sichtbar.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import os
-from flask import Flask
+import time
+from flask import Flask, Response, g, request
+
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+from app.logging import configure_logging
 
 from app.blueprints.admin import admin_bp
 from app.blueprints.api import api_bp
@@ -10,8 +15,27 @@ from app.blueprints.ui import ui_bp
 from app.extensions import csrf, limiter, login_manager
 from app.security import get_user_by_id
 
+try:  # pragma: no cover - optional dependency
+    import sentry_sdk
+    from sentry_sdk.integrations.flask import FlaskIntegration
+except Exception:  # pragma: no cover - optional dependency
+    sentry_sdk = None
+
+
+REQUEST_COUNT = Counter(
+    "flask_app_requests_total", "Total HTTP requests", ["method", "path", "status_code"]
+)
+REQUEST_LATENCY = Histogram(
+    "flask_app_request_latency_seconds", "Request latency", ["endpoint"]
+)
+
 
 def create_app() -> Flask:
+    configure_logging()
+    dsn = os.getenv("SENTRY_DSN")
+    if sentry_sdk and dsn:
+        sentry_sdk.init(dsn=dsn, integrations=[FlaskIntegration()])
+
     app = Flask(__name__)
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev-secret")
     app.config.update(
@@ -36,8 +60,28 @@ def create_app() -> Flask:
 
     limiter.limit("10/minute")(api_bp)
 
+    @app.before_request
+    def _start_timer() -> None:  # pragma: no cover - request timing
+        g.start_time = time.perf_counter()
+
+    @app.after_request
+    def _record_request(response: Response) -> Response:  # pragma: no cover - request timing
+        elapsed = time.perf_counter() - getattr(g, "start_time", time.perf_counter())
+        endpoint = request.endpoint or "unknown"
+        REQUEST_LATENCY.labels(endpoint).observe(elapsed)
+        REQUEST_COUNT.labels(request.method, request.path, response.status_code).inc()
+        return response
+
+    @app.route("/metrics")
+    def metrics() -> Response:
+        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+
     @app.route("/health")
     def health() -> tuple[str, int]:
+        return "ok", 200
+
+    @app.route("/ready")
+    def ready() -> tuple[str, int]:
         return "ok", 200
 
     return app

--- a/app/blueprints/api/items.py
+++ b/app/blueprints/api/items.py
@@ -1,4 +1,3 @@
-from flask import request
 from pydantic import BaseModel, Field
 
 

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,25 @@
+import json
+import logging
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """Logging formatter that outputs JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        log_record: dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def configure_logging() -> None:
+    """Configure root logger to use JSON formatting."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)

--- a/app/services/gematria/schemes.py
+++ b/app/services/gematria/schemes.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Gematria letter mappings for various schemes."""
+
+from __future__ import annotations
 
 from typing import Dict
 

--- a/app/services/ingest/rss.py
+++ b/app/services/ingest/rss.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """RSS/Atom ingestion helpers."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,10 +1,52 @@
 from __future__ import annotations
 
+import os
+import time
 from datetime import timedelta
 
 from celery import Celery
+from celery.signals import task_postrun, task_prerun, task_sent
+from prometheus_client import Gauge, Histogram
 
 from app import create_app
+from app.logging import configure_logging
+
+try:  # pragma: no cover - optional dependency
+    import sentry_sdk
+    from sentry_sdk.integrations.celery import CeleryIntegration
+except Exception:  # pragma: no cover - optional dependency
+    sentry_sdk = None
+
+
+configure_logging()
+dsn = os.getenv("SENTRY_DSN")
+if sentry_sdk and dsn:  # pragma: no cover - optional dependency
+    sentry_sdk.init(dsn=dsn, integrations=[CeleryIntegration()])
+
+task_duration = Histogram(
+    "celery_task_duration_seconds", "Task duration in seconds", ["task_name"]
+)
+queue_depth = Gauge("celery_queue_depth", "Number of tasks waiting in the queue")
+
+_start_times: dict[str, float] = {}
+
+
+@task_sent.connect
+def _task_sent_handler(**_kwargs) -> None:  # pragma: no cover - metrics bookkeeping
+    queue_depth.inc()
+
+
+@task_prerun.connect
+def _task_prerun_handler(task_id: str, task, **_kwargs) -> None:  # pragma: no cover
+    queue_depth.dec()
+    _start_times[task_id] = time.perf_counter()
+
+
+@task_postrun.connect
+def _task_postrun_handler(task_id: str, task, **_kwargs) -> None:  # pragma: no cover
+    start = _start_times.pop(task_id, None)
+    if start is not None:
+        task_duration.labels(task.name).observe(time.perf_counter() - start)
 
 flask_app = create_app()
 celery = Celery(
@@ -13,7 +55,7 @@ celery = Celery(
 celery.conf.update(flask_app.config)
 
 # Import task modules so Celery discovers them
-import app.tasks.ingest  # noqa: F401
+import app.tasks.ingest  # noqa: F401,E402
 
 # Simple beat schedule placeholder
 celery.conf.beat_schedule = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ opensearch-py
 pydantic
 PyYAML
 python-dotenv
+prometheus-client
+sentry-sdk
 # tests
 pytest
 pytest-cov

--- a/tests/test_gematria.py
+++ b/tests/test_gematria.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.services.gematria import compute_all, digital_root, factor_signature
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,11 @@
+from app import create_app
+
+
+def test_metrics_endpoint_counts_request():
+    app = create_app()
+    client = app.test_client()
+    # trigger a request to create metrics
+    client.get("/health")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"flask_app_requests_total" in resp.data

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -1,0 +1,9 @@
+from app import create_app
+
+
+def test_ready_endpoint():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.data == b"ok"


### PR DESCRIPTION
## Summary
- add JSON structured logging for app and worker
- expose Prometheus metrics and new /ready endpoint
- integrate Sentry, instrument Celery task metrics

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60d70ef4483308b30a9a834bbde40