### PR TITLE
Add deployment services and commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: install lint test format up
+service ?= web
+
+.PHONY: install lint test format up down logs migrate seed-rss
 
 install:
 	pip install -r requirements.txt
@@ -13,4 +15,16 @@ test:
 	pytest
 
 up:
-	docker compose up --build
+        docker compose up --build
+
+down:
+        docker compose down
+
+logs:
+        docker compose logs -f $(service)
+
+migrate:
+        docker compose run --rm web alembic upgrade head
+
+seed-rss:
+        docker compose run --rm web python scripts/seed_sources.py

--- a/Tasks.md
+++ b/Tasks.md
@@ -320,16 +320,16 @@ DoD: curl /metrics zeigt Counter/Gauges; Task-Laufzeiten sichtbar.
 
 10) Deployment (Docker Compose + Nginx)
 
-[ ] docker-compose.yml mit Services:
+[x] docker-compose.yml mit Services:
 
 web (gunicorn), worker, beat, nginx, postgres, opensearch, redis
 
 
-[ ] Nginx Reverse Proxy (GZip, HSTS optional, caching static)
+[x] Nginx Reverse Proxy (GZip, HSTS optional, caching static)
 
-[ ] Volumes/Backups: Postgres (pgdata), OS (osdata)
+[x] Volumes/Backups: Postgres (pgdata), OS (osdata)
 
-[ ] Commands
+[x] Commands
 
 make up / make down
 

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,5 +1,14 @@
+gzip on;
+gzip_types text/css application/javascript application/json text/plain;
+
 server {
     listen 80;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    location /static/ {
+        proxy_pass http://web:5000/static/;
+        expires 7d;
+        add_header Cache-Control "public";
+    }
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,42 @@ services:
     command: gunicorn wsgi:app --bind 0.0.0.0:5000
     volumes:
       - .:/app
-    ports:
-      - '5000:5000'
     env_file:
       - .env
     depends_on:
       - redis
       - postgres
       - opensearch
+  worker:
+    build: .
+    command: celery -A celery_app.celery worker --loglevel=INFO
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      - redis
+      - postgres
+      - opensearch
+  beat:
+    build: .
+    command: celery -A celery_app.celery beat --loglevel=INFO
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      - redis
+      - postgres
+      - opensearch
+  nginx:
+    image: nginx:1.25
+    ports:
+      - "80:80"
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
   redis:
     image: redis:7
   postgres:
@@ -22,9 +50,17 @@ services:
       POSTGRES_DB: gematria
       POSTGRES_USER: gematria
       POSTGRES_PASSWORD: gematria
+    volumes:
+      - pgdata:/var/lib/postgresql/data
   opensearch:
     image: opensearchproject/opensearch:2.11.1
     environment:
       discovery.type: single-node
     ports:
       - '9200:9200'
+    volumes:
+      - osdata:/usr/share/opensearch/data
+  
+volumes:
+  pgdata:
+  osdata:

--- a/scripts/seed_sources.py
+++ b/scripts/seed_sources.py
@@ -1,0 +1,15 @@
+"""Seed example RSS sources into the database.
+
+This is a placeholder script. In a real deployment it would insert
+predefined RSS sources so the ingest pipeline has data to process.
+"""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    print("Seeding example RSS sources...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand docker-compose with Celery worker, beat, Nginx proxy, and persistent volumes
- enhance Nginx with gzip, HSTS, and static caching
- add Makefile commands for deployment and seeding placeholder script

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c68c47db4c83308b339b7e2ebf76ba