### PR TITLE
feat: seed demo sources and alert

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -364,9 +364,9 @@ DoD: make test grün, Lint sauber.
 
 12) Beispiel-Seed & Demo
 
-[ ] Seed-Sources: 2–3 RSS (Reuters, AP), 1 Mastodon (public/hashtag), 1 YouTube-Channel
+[x] Seed-Sources: 2–3 RSS (Reuters, AP), 1 Mastodon (public/hashtag), 1 YouTube-Channel
 
-[ ] Seed-Alerts: 1 Regel für Wert 93, Quelle=Reuters
+[x] Seed-Alerts: 1 Regel für Wert 93, Quelle=Reuters
 
 [ ] Demo-Notebook (optional): Query + Plot (repro für Readme GIF)
 

--- a/scripts/seed_sources.py
+++ b/scripts/seed_sources.py
@@ -1,14 +1,83 @@
-"""Seed example RSS sources into the database.
-
-This is a placeholder script. In a real deployment it would insert
-predefined RSS sources so the ingest pipeline has data to process.
-"""
+"""Seed example sources and an alert into the database."""
 
 from __future__ import annotations
 
+import os
 
-def main() -> None:
-    print("Seeding example RSS sources...")
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.models import Alert, Base, Source
+
+
+def _session_from_env() -> Session:
+    """Create a session using the ``DATABASE_URL`` environment variable."""
+
+    engine = create_engine(os.getenv("DATABASE_URL", "sqlite:///app.db"))
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def seed_demo_data(session: Session) -> None:
+    """Insert demo sources and a sample alert if they don't exist."""
+
+    sources = [
+        Source(
+            name="Reuters",
+            type="rss",
+            endpoint="https://feeds.reuters.com/reuters/topNews",
+            interval_sec=300,
+        ),
+        Source(
+            name="Associated Press",
+            type="rss",
+            endpoint="https://apnews.com/apf-topnews?format=rss",
+            interval_sec=300,
+        ),
+        Source(
+            name="Mastodon #news",
+            type="mastodon",
+            endpoint="https://mastodon.social/tags/news.rss",
+            interval_sec=300,
+        ),
+        Source(
+            name="YouTube Channel",
+            type="youtube",
+            endpoint="https://www.youtube.com/feeds/videos.xml?channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw",
+            interval_sec=300,
+        ),
+    ]
+
+    for src in sources:
+        exists = session.query(Source).filter_by(endpoint=src.endpoint).first()
+        if not exists:
+            session.add(src)
+
+    alert_rule = """
+when:
+  all:
+    - scheme: ordinal
+      value_in: [93]
+    - source_in: ["Reuters"]
+    - window: { period: "24h", min_count: 1 }
+"""
+    alert = session.query(Alert).filter_by(name="reuters_93").first()
+    if alert is None:
+        session.add(Alert(name="reuters_93", rule_yaml=alert_rule))
+
+    session.commit()
+
+
+def main(*, session: Session | None = None) -> None:
+    close = False
+    if session is None:
+        session = _session_from_env()
+        close = True
+
+    seed_demo_data(session)
+
+    if close:
+        session.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_seed_sources.py
+++ b/tests/test_seed_sources.py
@@ -1,0 +1,25 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.models import Alert, Base, Source
+from scripts import seed_sources
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_seed_demo_data_creates_sources_and_alert():
+    session = _session()
+    seed_sources.main(session=session)
+
+    sources = session.query(Source).all()
+    assert len(sources) == 4
+    names = {s.name for s in sources}
+    assert {"Reuters", "Associated Press", "Mastodon #news", "YouTube Channel"} == names
+
+    alerts = session.query(Alert).all()
+    assert len(alerts) == 1
+    assert "value_in: [93]" in alerts[0].rule_yaml


### PR DESCRIPTION
## Summary
- seed sample RSS, Mastodon, and YouTube sources
- add demo alert rule for value 93 from Reuters
- mark Task 12 items as complete and test seeding

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c69d905ea08330ac4f9f3dd19869d3