### PR TITLE
Fix overview template encoding and restore base layout

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>The Watcher</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='dist/assets/style.css') }}">
+    <script type="module" defer src="{{ url_for('static', filename='dist/main.js') }}"></script>
+  </head>
+  <body data-page="{{ request.endpoint }}">
+    <header class="site-header">
+      <div class="nav-wrapper">
+        <a class="brand" href="{{ url_for('ui.overview') }}">
+          <span class="brand-icon" aria-hidden="true">W</span>
+          <span>The Watcher</span>
+        </a>
+        <nav class="primary-nav" aria-label="Hauptnavigation">
+          <a href="{{ url_for('ui.overview') }}" {% if request.endpoint == 'ui.overview' %}aria-current="page"{% endif %}>Overview</a>
+          <a href="{{ url_for('ui.stream') }}" {% if request.endpoint == 'ui.stream' %}aria-current="page"{% endif %}>Stream</a>
+          <a href="{{ url_for('ui.heatmap') }}" {% if request.endpoint == 'ui.heatmap' %}aria-current="page"{% endif %}>Heatmap</a>
+          <a href="{{ url_for('ui.graph') }}" {% if request.endpoint == 'ui.graph' %}aria-current="page"{% endif %}>Graph</a>
+          <a href="{{ url_for('ui.alerts') }}" {% if request.endpoint == 'ui.alerts' %}aria-current="page"{% endif %}>Alerts</a>
+          <a href="{{ url_for('ui.admin') }}" {% if request.endpoint == 'ui.admin' %}aria-current="page"{% endif %}>Admin</a>
+          <a href="{{ url_for('ui.patterns') }}" {% if request.endpoint == 'ui.patterns' %}aria-current="page"{% endif %}>Patterns</a>
+        </nav>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">🌗</span>
+          <span data-role="label">Light</span>
+        </button>
+      </div>
+    </header>
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/app/templates/ui/overview.html
+++ b/app/templates/ui/overview.html
@@ -3,7 +3,7 @@
 <section class="hero">
   <div class="hero-copy">
     <h1>Realtime Intelligence Cockpit</h1>
-    <p>Behalte Quellen, Alerts und Muster im Blick – aggregiert in einer modernen Oberfläche mit Interaktionen in Echtzeit.</p>
+    <p>Behalte Quellen, Alerts und Muster im Blick â€“ aggregiert in einer modernen OberflÃ¤che mit Interaktionen in Echtzeit.</p>
     <p class="status-message" data-overview-status>Live-Status wird geladen...</p>
   </div>
 </section>
@@ -11,19 +11,19 @@
 <section class="dashboard-grid" data-overview>
   <article class="stat-card">
     <span class="stat-label">Aktive Quellen</span>
-    <span class="stat-value" data-metric="sources">–</span>
+    <span class="stat-value" data-metric="sources">â€“</span>
   </article>
   <article class="stat-card">
     <span class="stat-label">Items (24h)</span>
-    <span class="stat-value" data-metric="items">–</span>
+    <span class="stat-value" data-metric="items">â€“</span>
   </article>
   <article class="stat-card">
     <span class="stat-label">Alerts (24h)</span>
-    <span class="stat-value" data-metric="alerts">–</span>
+    <span class="stat-value" data-metric="alerts">â€“</span>
   </article>
   <article class="stat-card">
     <span class="stat-label">Top Pattern Score</span>
-    <span class="stat-value" data-metric="pattern-score">–</span>
+    <span class="stat-value" data-metric="pattern-score">â€“</span>
   </article>
 </section>
 


### PR DESCRIPTION
## Summary
- re-encode the overview page template as UTF-8 so Flask can render it without raising UnicodeDecodeError
- restore the base layout with navigation, theme toggle, and bundled static assets so UI routes return content again

## Testing
- `pytest tests/test_ui.py tests/test_metrics.py tests/test_ingest.py::test_run_source_creates_items_and_gematria` *(fails: existing issues in tests/test_metrics.py and tests/test_ingest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d11c1ee93483309978f9d02c53678c