### PR TITLE
Fix Celery beat ping task registration

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -98,11 +98,13 @@ celery.conf.update(flask_app.config)
 # Import task modules so Celery discovers them
 import app.tasks.ingest  # noqa: F401,E402
 
-# Simple beat schedule placeholder
-celery.conf.beat_schedule = {"ping": {"task": "ping", "schedule": timedelta(minutes=1)}}
-
-
 @celery.task
 def ping() -> str:
     return "pong"
+
+
+# Simple beat schedule placeholder
+celery.conf.beat_schedule = {
+    "ping": {"task": ping.name, "schedule": timedelta(minutes=1)}
+}
 


### PR DESCRIPTION
## Summary
- ensure the Celery beat schedule references the registered ping task name so beat jobs run

## Testing
- pytest *(fails: tests/test_ingest.py::test_run_source_creates_items_and_gematria, tests/test_metrics.py::test_metrics_endpoint_counts_request)*

------
https://chatgpt.com/codex/tasks/task_e_68d11facadf483308346d3d42e3a9603