### PR TITLE
Remove obsolete version field from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   web:
     build: .


### PR DESCRIPTION
## Summary
- remove the deprecated top-level `version` entry from `docker-compose.yml` to align with the latest Compose specification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d122713b788330a55d1e37a7f413d1