### PR TITLE
Schedule ingestion and analytics tasks in Celery beat

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -104,7 +104,24 @@ def ping() -> str:
 
 
 # Simple beat schedule placeholder
+# Periodic task schedule
 celery.conf.beat_schedule = {
-    "ping": {"task": ping.name, "schedule": timedelta(minutes=1)}
+    "ping": {"task": ping.name, "schedule": timedelta(minutes=1)},
+    # Regularly check which sources need to be scraped so that the UI shows data
+    # without requiring manual task invocation.
+    "ingest-due-sources": {
+        "task": "run_due_sources",
+        "schedule": timedelta(minutes=1),
+    },
+    # Evaluate alerts shortly after ingestion so the dashboard stays in sync.
+    "evaluate-alerts": {
+        "task": "evaluate_alerts",
+        "schedule": timedelta(minutes=2),
+    },
+    # Pattern discovery is slightly more expensive; run it less frequently.
+    "discover-patterns": {
+        "task": "discover_patterns",
+        "schedule": timedelta(minutes=15),
+    },
 }
 


### PR DESCRIPTION
## Summary
- configure Celery beat to run ingestion, alert evaluation and pattern discovery periodically
- ensure sources are scraped automatically so the UI displays live data without manual task triggers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d137ecf628833087056d10fab6196d