### PR TITLE
Fix configuration defaults for local development

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,12 +37,12 @@ def create_app() -> Flask:
         sentry_sdk.init(dsn=dsn, integrations=[FlaskIntegration()])
 
     app = Flask(__name__)
-    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev-secret")
-    app.config.update(
-        SESSION_COOKIE_HTTPONLY=True,
-        SESSION_COOKIE_SECURE=True,
-        SESSION_COOKIE_SAMESITE="Lax",
-    )
+    app.config.from_object("config.Config")
+
+    # Ensure a development-friendly secret key when none has been configured.
+    app.config.setdefault("SECRET_KEY", os.getenv("SECRET_KEY", "dev-secret"))
+    app.config.setdefault("SESSION_COOKIE_HTTPONLY", True)
+    app.config.setdefault("SESSION_COOKIE_SAMESITE", "Lax")
 
     login_manager.init_app(app)
     csrf.init_app(app)

--- a/celery_app.py
+++ b/celery_app.py
@@ -90,9 +90,10 @@ def _task_postrun_handler(task_id: str, task, **_kwargs) -> None:  # pragma: no 
 
 
 flask_app = create_app()
-celery = Celery(
-    __name__, broker=flask_app.config.get("REDIS_URL", "redis://redis:6379/0")
+broker_url = flask_app.config.get("REDIS_URL") or os.getenv(
+    "REDIS_URL", "redis://localhost:6379/0"
 )
+celery = Celery(__name__, broker=broker_url)
 celery.conf.update(flask_app.config)
 
 # Import task modules so Celery discovers them

--- a/config.py
+++ b/config.py
@@ -1,8 +1,36 @@
 import os
+from typing import Optional
+
+
+def _get_bool_env(name: str, default: bool = False) -> bool:
+    """Return a boolean configuration value based on an environment variable."""
+
+    value = os.getenv(name)
+    if value is None:
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Read an environment variable returning ``default`` when unset or empty."""
+
+    value = os.getenv(name)
+    if value in (None, ""):
+        return default
+    return value
 
 
 class Config:
-    SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
-    DATABASE_URL = os.getenv("DATABASE_URL")
-    OPENSEARCH_HOST = os.getenv("OPENSEARCH_HOST", "http://localhost:9200")
-    REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    SECRET_KEY = _get_env("SECRET_KEY", "change-me")
+    DATABASE_URL = _get_env("DATABASE_URL")
+    OPENSEARCH_HOST = _get_env("OPENSEARCH_HOST", "http://localhost:9200")
+    REDIS_URL = _get_env("REDIS_URL", "redis://localhost:6379/0")
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SECURE = _get_bool_env("SESSION_COOKIE_SECURE", False)
+    SESSION_COOKIE_SAMESITE = _get_env("SESSION_COOKIE_SAMESITE", "Lax")


### PR DESCRIPTION
## Summary
- load the shared configuration object when creating the Flask app so environment settings are honoured
- expose helpers for reading env vars and default session cookie flags to values that work in local HTTP development
- ensure the Celery app uses the configured Redis URL instead of assuming a docker hostname

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d13e3d26388330bab1a2f0475d7c06