### PR TITLE
Add configurable gematria schemes and UI management

### DIFF
--- a/app/blueprints/api/admin.py
+++ b/app/blueprints/api/admin.py
@@ -12,7 +12,14 @@ from app.db import get_session
 from app.extensions import csrf
 from app.models import Source
 from app.security import role_required
-from app.services.settings import get_worker_settings, update_worker_settings
+from app.services.gematria import list_available_schemes
+from app.services.settings import (
+    DEFAULT_GEMATRIA_SETTINGS,
+    get_gematria_settings,
+    get_worker_settings,
+    update_gematria_settings,
+    update_worker_settings,
+)
 from app.services.workers import (
     WorkerCommandError,
     WorkerUnavailableError,
@@ -71,6 +78,18 @@ def _open_session():
     return get_session(_database_url())
 
 
+def _serialize_gematria_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "enabled": settings.get("enabled_schemes", []),
+        "ignore_pattern": settings.get("ignore_pattern"),
+        "available": list_available_schemes(),
+        "defaults": {
+            "enabled": list(DEFAULT_GEMATRIA_SETTINGS.enabled_schemes),
+            "ignore_pattern": DEFAULT_GEMATRIA_SETTINGS.ignore_pattern,
+        },
+    }
+
+
 @admin_api_bp.get("/worker-settings")
 @login_required
 @role_required("admin")
@@ -93,6 +112,32 @@ def update_worker_settings_endpoint():
         payload = request.get_json() or {}
         settings = update_worker_settings(session, payload)
         return jsonify(settings), 200
+    finally:
+        session.close()
+
+
+@admin_api_bp.get("/gematria-settings")
+@login_required
+@role_required("admin")
+def get_gematria_settings_endpoint():
+    session = _open_session()
+    try:
+        settings = get_gematria_settings(session)
+        return jsonify(_serialize_gematria_settings(settings)), 200
+    finally:
+        session.close()
+
+
+@admin_api_bp.put("/gematria-settings")
+@csrf.exempt
+@login_required
+@role_required("admin")
+def update_gematria_settings_endpoint():
+    session = _open_session()
+    try:
+        payload = request.get_json() or {}
+        settings = update_gematria_settings(session, payload)
+        return jsonify(_serialize_gematria_settings(settings)), 200
     finally:
         session.close()
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -59,22 +59,19 @@ class Item(Base):
     raw_json: Mapped[Optional[dict]] = mapped_column(JSON)
 
     source: Mapped["Source"] = relationship("Source", back_populates="items")
-    gematria: Mapped[Optional["Gematria"]] = relationship(
-        "Gematria", back_populates="item", uselist=False
-    )
+    gematria: Mapped[List["Gematria"]] = relationship("Gematria", back_populates="item")
     item_tags: Mapped[List["ItemTag"]] = relationship("ItemTag", back_populates="item")
 
 
 class Gematria(Base):
     __tablename__ = "gematria"
     __table_args__ = (
-        UniqueConstraint("item_id"),
         Index("ix_gematria_value", "value"),
         Index("ix_gematria_scheme", "scheme"),
     )
 
     item_id: Mapped[int] = mapped_column(ForeignKey("items.id"), primary_key=True)
-    scheme: Mapped[str] = mapped_column(String(50), nullable=False)
+    scheme: Mapped[str] = mapped_column(String(50), primary_key=True)
     value: Mapped[int] = mapped_column(Integer, nullable=False)
     token_count: Mapped[Optional[int]] = mapped_column(Integer)
     normalized_title: Mapped[Optional[str]] = mapped_column(Text)

--- a/app/services/gematria/__init__.py
+++ b/app/services/gematria/__init__.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
-from .schemes import SCHEMES
+from .schemes import (
+    DEFAULT_ENABLED_SCHEMES,
+    SCHEMES,
+    available_scheme_metadata,
+)
 
 
 def normalize(text: str, *, ignore_pattern: str = r"[^A-Z]") -> str:
@@ -26,9 +30,24 @@ def compute_all(
     normalized = normalize(text, ignore_pattern=ignore_pattern)
     results: Dict[str, int] = {}
     for name in schemes:
-        mapping = SCHEMES[name]
+        mapping = SCHEMES.get(name)
+        if mapping is None:
+            continue
         results[name] = sum(mapping.get(ch, 0) for ch in normalized)
     return results
+
+
+def list_available_schemes() -> List[Dict[str, str]]:
+    """Return metadata describing the configured gematria schemes."""
+
+    return [
+        {
+            "key": definition.key,
+            "label": definition.label,
+            "description": definition.description,
+        }
+        for definition in available_scheme_metadata()
+    ]
 
 
 def digital_root(n: int) -> int:
@@ -54,4 +73,12 @@ def factor_signature(n: int) -> Dict[int, int]:
     return factors
 
 
-__all__ = ["SCHEMES", "normalize", "compute_all", "digital_root", "factor_signature"]
+__all__ = [
+    "DEFAULT_ENABLED_SCHEMES",
+    "SCHEMES",
+    "compute_all",
+    "digital_root",
+    "factor_signature",
+    "list_available_schemes",
+    "normalize",
+]

--- a/app/services/gematria/schemes.py
+++ b/app/services/gematria/schemes.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class SchemeDefinition:
+    """Metadata and mapping for a gematria scheme."""
+
+    key: str
+    label: str
+    description: str
+    mapping: Dict[str, int]
 
 
 def _build_ordinal() -> Dict[str, int]:
@@ -23,12 +34,105 @@ def _build_reverse_reduction() -> Dict[str, int]:
     return {ch: (val - 1) % 9 + 1 for ch, val in reverse.items()}
 
 
-SCHEMES: Dict[str, Dict[str, int]] = {
-    "ordinal": _build_ordinal(),
-    "reduction": _build_reduction(),
-    "reverse": _build_reverse(),
-    "reverse_reduction": _build_reverse_reduction(),
+def _build_prime() -> Dict[str, int]:
+    primes = [
+        2,
+        3,
+        5,
+        7,
+        11,
+        13,
+        17,
+        19,
+        23,
+        29,
+        31,
+        37,
+        41,
+        43,
+        47,
+        53,
+        59,
+        61,
+        67,
+        71,
+        73,
+        79,
+        83,
+        89,
+        97,
+        101,
+    ]
+    return {chr(ord("A") + i): primes[i] for i in range(26)}
+
+
+def _build_sumerian() -> Dict[str, int]:
+    ordinal = _build_ordinal()
+    return {ch: val * 6 for ch, val in ordinal.items()}
+
+
+SCHEME_DEFINITIONS: Dict[str, SchemeDefinition] = {
+    "ordinal": SchemeDefinition(
+        key="ordinal",
+        label="Ordinal",
+        description="Klassische Zuordnung A=1 … Z=26.",
+        mapping=_build_ordinal(),
+    ),
+    "reduction": SchemeDefinition(
+        key="reduction",
+        label="Pythagoräisch",
+        description="Reduktion der Ordinalwerte auf einstellige Zahlen (1–9).",
+        mapping=_build_reduction(),
+    ),
+    "reverse": SchemeDefinition(
+        key="reverse",
+        label="Reverse Ordinal",
+        description="Spiegelung: Z=1 … A=26.",
+        mapping=_build_reverse(),
+    ),
+    "reverse_reduction": SchemeDefinition(
+        key="reverse_reduction",
+        label="Reverse Pythagoräisch",
+        description="Reduktion der gespiegelten Ordinalwerte auf 1–9.",
+        mapping=_build_reverse_reduction(),
+    ),
+    "prime": SchemeDefinition(
+        key="prime",
+        label="Primzahlen",
+        description="Zuweisung der ersten 26 Primzahlen (A=2 … Z=101).",
+        mapping=_build_prime(),
+    ),
+    "sumerian": SchemeDefinition(
+        key="sumerian",
+        label="Sumerisch",
+        description="Ordinalwerte multipliziert mit 6 (A=6 … Z=156).",
+        mapping=_build_sumerian(),
+    ),
 }
 
 
-__all__ = ["SCHEMES"]
+SCHEMES: Dict[str, Dict[str, int]] = {
+    key: definition.mapping for key, definition in SCHEME_DEFINITIONS.items()
+}
+
+
+DEFAULT_ENABLED_SCHEMES: Tuple[str, ...] = (
+    "ordinal",
+    "reduction",
+    "reverse",
+)
+
+
+def available_scheme_metadata() -> Iterable[SchemeDefinition]:
+    """Return scheme definitions sorted by label for display purposes."""
+
+    return sorted(SCHEME_DEFINITIONS.values(), key=lambda definition: definition.label)
+
+
+__all__ = [
+    "DEFAULT_ENABLED_SCHEMES",
+    "SCHEMES",
+    "SCHEME_DEFINITIONS",
+    "SchemeDefinition",
+    "available_scheme_metadata",
+]

--- a/app/templates/ui/admin.html
+++ b/app/templates/ui/admin.html
@@ -57,6 +57,44 @@
     </form>
   </section>
 
+  <section class="card admin-card" data-admin-gematria>
+    <div class="admin-card__header">
+      <div>
+        <h2>Gematria-Konfiguration</h2>
+        <p class="lead">
+          Lege fest, welche Ciphers berechnet werden und welche Zeichen berücksichtigt sind.
+        </p>
+      </div>
+      <div class="admin-card__header-actions">
+        <button type="button" class="button subtle" data-gematria-select-all>
+          Alle aktivieren
+        </button>
+        <button type="button" class="button subtle" data-gematria-reset>
+          Zurücksetzen
+        </button>
+      </div>
+    </div>
+    <p class="status-message" data-gematria-status hidden></p>
+    <form class="admin-form" data-gematria-form>
+      <fieldset class="scheme-grid" data-gematria-list>
+        <legend class="visually-hidden">Verfügbare Gematria-Ciphers</legend>
+      </fieldset>
+      <label class="form-control" for="gematria-ignore">
+        <span>Regex für erlaubte Zeichen (Leer lassen für Standard)</span>
+        <input
+          type="text"
+          id="gematria-ignore"
+          name="ignore_pattern"
+          placeholder="[^A-Z]"
+          autocomplete="off"
+        />
+      </label>
+      <div class="form-actions">
+        <button type="submit" class="button primary">Speichern</button>
+      </div>
+    </form>
+  </section>
+
   <section class="card admin-card" data-admin-sources>
     <h2>Quellen &amp; RSS</h2>
     <p class="status-message" data-source-status hidden></p>

--- a/frontend/styles/components.css
+++ b/frontend/styles/components.css
@@ -214,6 +214,70 @@
   gap: 0.35rem;
 }
 
+.scheme-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.scheme-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  background: var(--color-surface-alt);
+  cursor: pointer;
+  transition: border var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.scheme-option:hover,
+.scheme-option:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 12%, transparent);
+}
+
+.scheme-option input[type="checkbox"] {
+  margin: 0.2rem 0 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+}
+
+.scheme-option__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.scheme-option__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.scheme-option__meta {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.scheme-option__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.scheme-empty {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
 .admin-card__header {
   display: flex;
   align-items: flex-start;
@@ -537,6 +601,20 @@
 .button:focus-visible {
   background: color-mix(in srgb, var(--color-primary) 12%, var(--color-surface-alt));
   border-color: color-mix(in srgb, var(--color-primary) 25%, var(--color-border));
+}
+
+.button.subtle {
+  background: transparent;
+  border-color: color-mix(in srgb, var(--color-border) 40%, transparent);
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.button.subtle:hover,
+.button.subtle:focus-visible {
+  color: var(--color-primary);
+  border-color: color-mix(in srgb, var(--color-primary) 40%, transparent);
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
 }
 
 .button.primary {

--- a/migrations/versions/6fcfdba8f775_init.py
+++ b/migrations/versions/6fcfdba8f775_init.py
@@ -115,8 +115,7 @@ def upgrade() -> None:
             ["item_id"],
             ["items.id"],
         ),
-        sa.PrimaryKeyConstraint("item_id"),
-        sa.UniqueConstraint("item_id"),
+        sa.PrimaryKeyConstraint("item_id", "scheme"),
     )
     op.create_index("ix_gematria_scheme", "gematria", ["scheme"], unique=False)
     op.create_index("ix_gematria_value", "gematria", ["value"], unique=False)

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -66,6 +66,36 @@ def test_worker_settings_flow(client_with_db):
         session.close()
 
 
+def test_gematria_settings_flow(client_with_db):
+    client, db_url = client_with_db
+    _login(client)
+
+    resp = client.get("/api/admin/gematria-settings")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["available"], list) and data["available"]
+    assert isinstance(data["enabled"], list) and data["enabled"]
+    assert "defaults" in data and isinstance(data["defaults"].get("enabled"), list)
+
+    update_resp = client.put(
+        "/api/admin/gematria-settings",
+        json={"enabled": ["prime", "sumerian"], "ignore_pattern": "[^A-ZÄÖÜ]"},
+    )
+    assert update_resp.status_code == 200
+    updated = update_resp.get_json()
+    assert updated["enabled"] == ["prime", "sumerian"]
+    assert updated["ignore_pattern"] == "[^A-ZÄÖÜ]"
+
+    session = get_session(db_url)
+    try:
+        setting = session.get(Setting, "gematria.settings")
+        assert setting is not None
+        assert setting.value_json["enabled_schemes"] == ["prime", "sumerian"]
+        assert setting.value_json["ignore_pattern"] == "[^A-ZÄÖÜ]"
+    finally:
+        session.close()
+
+
 def test_sources_crud(client_with_db):
     client, db_url = client_with_db
     _login(client)

--- a/tests/test_gematria.py
+++ b/tests/test_gematria.py
@@ -1,4 +1,10 @@
-from app.services.gematria import compute_all, digital_root, factor_signature
+from app.services.gematria import (
+    DEFAULT_ENABLED_SCHEMES,
+    compute_all,
+    digital_root,
+    factor_signature,
+    list_available_schemes,
+)
 
 
 def test_compute_all_known_examples():
@@ -28,6 +34,12 @@ def test_compute_all_empty_string():
     assert compute_all("", ["ordinal"]) == {"ordinal": 0}
 
 
+def test_compute_all_additional_schemes():
+    text = "CAB"
+    result = compute_all(text, ["prime", "sumerian"])
+    assert result == {"prime": 10, "sumerian": 36}
+
+
 def test_digital_root():
     assert digital_root(942) == 6
     assert digital_root(0) == 0
@@ -37,3 +49,15 @@ def test_factor_signature():
     assert factor_signature(84) == {2: 2, 3: 1, 7: 1}
     assert factor_signature(13) == {13: 1}
     assert factor_signature(1) == {}
+
+
+def test_list_available_schemes_contains_metadata():
+    schemes = list_available_schemes()
+    assert any(entry["key"] == "ordinal" for entry in schemes)
+    assert all("label" in entry and "description" in entry for entry in schemes)
+
+
+def test_default_enabled_schemes_are_known():
+    available = {entry["key"] for entry in list_available_schemes()}
+    for scheme in DEFAULT_ENABLED_SCHEMES:
+        assert scheme in available

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,8 +56,13 @@ def test_gematria_relationship(session: Session):
     session.add(gem)
     session.commit()
 
-    fetched = session.get(Gematria, item.id)
+    session.refresh(item)
+    fetched = session.get(Gematria, (item.id, "ordinal"))
+    assert fetched is not None
     assert fetched.item.id == item.id
+    assert fetched.scheme == "ordinal"
+    assert fetched.value == 42
+    assert len(item.gematria) == 1
 
 
 def test_tag_association(session: Session):


### PR DESCRIPTION
## Summary
- add extended gematria scheme metadata with new prime and sumerian mappings and expose scheme listings
- persist multiple gematria schemes per item and respect admin-configured settings during ingestion
- provide admin API endpoints, UI controls, and styling to manage enabled gematria ciphers and ignore patterns
- extend automated tests to cover gematria settings API, scheme metadata, and ingestion behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1506756808330b073af6f76c9fb91