### PR TITLE
Add pgAdmin service to docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Makefile            Common development and deployment helpers
    ```
 5. The UI and API are served via Nginx on [http://localhost](http://localhost). The Flask service
    itself listens on port 5000. PostgreSQL and OpenSearch are exposed on their standard ports for
-   debugging.
+   debugging, and pgAdmin is available on [http://localhost:5050](http://localhost:5050) with the
+   default credentials `admin@example.com` / `admin` (adjust these in `docker-compose.yml` or your
+   `.env`).
 6. Optional: initialize the OpenSearch index from a Python shell using
    `app.services.search.create_items_index`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,19 @@ services:
       - '9200:9200'
     volumes:
       - osdata:/usr/share/opensearch/data
-  
+  pgadmin:
+    image: dpage/pgadmin4:8.6
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    volumes:
+      - pgadmin:/var/lib/pgadmin
+    depends_on:
+      - postgres
+
 volumes:
   pgdata:
   osdata:
+  pgadmin:


### PR DESCRIPTION
## Summary
- add a pgAdmin container to the docker-compose stack with persistent storage and default credentials
- document pgAdmin access details in the Docker Compose section of the README

## Testing
- docker compose config *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d267bc98308330a7447aec70c0acf4