### PR TITLE
Fix gematria duplicate key errors

### DIFF
--- a/app/tasks/ingest.py
+++ b/app/tasks/ingest.py
@@ -48,6 +48,10 @@ def compute_gematria_for_item(
 
     gematria_settings = get_gematria_settings(session)
     enabled_schemes = gematria_settings.get("enabled_schemes", [])
+    if enabled_schemes:
+        # Preserve user-defined ordering but avoid duplicates that could trigger
+        # redundant INSERTs for the same (item_id, scheme) pair.
+        enabled_schemes = list(dict.fromkeys(enabled_schemes))
     ignore_pattern = gematria_settings.get("ignore_pattern", r"[^A-Z]")
     values = compute_all(item.title, enabled_schemes, ignore_pattern=ignore_pattern)
     normalized = normalize(item.title, ignore_pattern=ignore_pattern)

--- a/migrations/versions/8f0c6e3c4a99_fix_gematria_primary_key.py
+++ b/migrations/versions/8f0c6e3c4a99_fix_gematria_primary_key.py
@@ -1,0 +1,26 @@
+"""Fix gematria primary key to include scheme column.
+
+Revision ID: 8f0c6e3c4a99
+Revises: f34c0dfecc5c
+Create Date: 2025-09-23 10:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "8f0c6e3c4a99"
+down_revision: Union[str, Sequence[str], None] = "f34c0dfecc5c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("gematria_pkey", "gematria", type_="primary")
+    op.create_primary_key("gematria_pkey", "gematria", ["item_id", "scheme"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("gematria_pkey", "gematria", type_="primary")
+    op.create_primary_key("gematria_pkey", "gematria", ["item_id"])


### PR DESCRIPTION
## Summary
- ensure enabled gematria schemes are de-duplicated before persistence to avoid redundant inserts
- add an Alembic migration that recreates the gematria primary key to include the scheme column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d266f281c88330b04dd08cb7289652