### PR TITLE
Add SQL schema initialization for Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,8 @@ COPY . .
 # Frontend bauen (falls vorhanden)
 RUN npm run build
 
+RUN chmod +x scripts/entrypoint.sh
+
 EXPOSE 5000
+ENTRYPOINT ["./scripts/entrypoint.sh"]
 CMD ["gunicorn", "wsgi:app", "--bind", "0.0.0.0:5000", "--workers", "3", "--threads", "2", "--timeout", "60"]

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -1,0 +1,97 @@
+-- Database schema for The Watcher application.
+-- This script is idempotent and can be executed multiple times safely.
+
+CREATE TABLE IF NOT EXISTS sources (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    endpoint TEXT NOT NULL,
+    enabled BOOLEAN DEFAULT TRUE,
+    interval_sec INTEGER DEFAULT 0,
+    auth_json JSONB,
+    filters_json JSONB,
+    last_run_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS items (
+    id SERIAL PRIMARY KEY,
+    source_id INTEGER NOT NULL REFERENCES sources(id),
+    fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    published_at TIMESTAMP,
+    url TEXT NOT NULL,
+    title TEXT,
+    author VARCHAR(255),
+    lang VARCHAR(8),
+    dedupe_hash VARCHAR(64),
+    raw_json JSONB,
+    CONSTRAINT uq_items_url UNIQUE (url)
+);
+
+CREATE INDEX IF NOT EXISTS ix_item_published_at ON items (published_at);
+CREATE INDEX IF NOT EXISTS ix_item_dedupe_hash ON items (dedupe_hash);
+
+CREATE TABLE IF NOT EXISTS gematria (
+    item_id INTEGER NOT NULL REFERENCES items(id),
+    scheme VARCHAR(50) NOT NULL,
+    value INTEGER NOT NULL,
+    token_count INTEGER,
+    normalized_title TEXT,
+    PRIMARY KEY (item_id, scheme)
+);
+
+CREATE INDEX IF NOT EXISTS ix_gematria_value ON gematria (value);
+CREATE INDEX IF NOT EXISTS ix_gematria_scheme ON gematria (scheme);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id SERIAL PRIMARY KEY,
+    label VARCHAR(50) UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS item_tags (
+    item_id INTEGER NOT NULL REFERENCES items(id),
+    tag_id INTEGER NOT NULL REFERENCES tags(id),
+    weight DOUBLE PRECISION DEFAULT 1.0,
+    PRIMARY KEY (item_id, tag_id)
+);
+
+CREATE TABLE IF NOT EXISTS alerts (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    enabled BOOLEAN DEFAULT TRUE,
+    rule_yaml TEXT NOT NULL,
+    last_eval_at TIMESTAMP,
+    notify_json JSONB,
+    severity INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id SERIAL PRIMARY KEY,
+    alert_id INTEGER NOT NULL REFERENCES alerts(id),
+    triggered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    payload_json JSONB,
+    severity INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    role VARCHAR(50) DEFAULT 'user',
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key VARCHAR(255) PRIMARY KEY,
+    value_json JSONB
+);
+
+CREATE TABLE IF NOT EXISTS patterns (
+    id SERIAL PRIMARY KEY,
+    label VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    top_terms JSONB,
+    anomaly_score DOUBLE PRECISION,
+    item_ids JSONB,
+    meta JSONB
+);

--- a/scripts/apply_schema.py
+++ b/scripts/apply_schema.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
+
+
+RETRY_ATTEMPTS = 10
+RETRY_DELAY = 2
+
+
+def _load_statements(schema_path: Path) -> list[str]:
+    sql = schema_path.read_text(encoding="utf-8")
+    statements: list[str] = []
+    buffer: list[str] = []
+
+    for line in sql.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+
+        buffer.append(line)
+        if stripped.endswith(";"):
+            statement = "\n".join(buffer).rstrip(";\n ")
+            statements.append(statement)
+            buffer = []
+
+    if buffer:
+        statements.append("\n".join(buffer).rstrip(";\n "))
+
+    return statements
+
+
+def apply_schema() -> None:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL not set; skipping schema initialization.")
+        return
+
+    if database_url.startswith("sqlite"):
+        print("DATABASE_URL points to SQLite; skipping schema initialization.")
+        return
+
+    schema_path = Path(__file__).resolve().parent.parent / "database-schema.sql"
+    if not schema_path.exists():
+        raise FileNotFoundError(f"Schema file not found: {schema_path}")
+
+    statements = _load_statements(schema_path)
+    if not statements:
+        print("No SQL statements found in schema file; nothing to execute.")
+        return
+
+    engine = create_engine(database_url, future=True)
+
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            with engine.begin() as connection:
+                for statement in statements:
+                    connection.exec_driver_sql(statement)
+            print("Database schema ensured via database-schema.sql.")
+            break
+        except OperationalError as exc:  # pragma: no cover - requires failing DB
+            if attempt == RETRY_ATTEMPTS:
+                raise
+            print(
+                "Database not ready yet (attempt %s/%s): %s" %
+                (attempt, RETRY_ATTEMPTS, exc)
+            )
+            time.sleep(RETRY_DELAY)
+
+
+def main() -> None:
+    apply_schema()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -n "${DATABASE_URL:-}" ]; then
+    echo "Applying database schema from database-schema.sql..."
+    python scripts/apply_schema.py
+else
+    echo "DATABASE_URL not set; skipping schema initialization."
+fi
+
+echo "Starting service: $*"
+exec "$@"


### PR DESCRIPTION
## Summary
- add an idempotent `database-schema.sql` that captures the application tables
- run the schema automatically on container start via a lightweight Python helper and entrypoint script
- update the Docker image to use the entrypoint before launching app services

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d26948a7208330a172b4c95bc39a00