### PR TITLE
Ensure database schema applies within public search path

### DIFF
--- a/database-schema.sql
+++ b/database-schema.sql
@@ -1,5 +1,10 @@
--- Database schema for The Watcher application.
 -- This script is idempotent and can be executed multiple times safely.
+
+-- Ensure the default schema exists and is active for the session. This avoids
+-- "no schema has been selected to create in" errors when the search_path is
+-- cleared by managed database providers or client configuration.
+CREATE SCHEMA IF NOT EXISTS public;
+SET search_path TO public;
 
 CREATE TABLE IF NOT EXISTS sources (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- ensure the SQL bootstrap script explicitly creates and selects the public schema before creating tables to avoid "no schema selected" errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d26caa564483308fa84bfcb8d5dcff