### PR TITLE
Fix Docker entrypoint path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ RUN npm run build
 RUN chmod +x scripts/entrypoint.sh
 
 EXPOSE 5000
-ENTRYPOINT ["./scripts/entrypoint.sh"]
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 CMD ["gunicorn", "wsgi:app", "--bind", "0.0.0.0:5000", "--workers", "3", "--threads", "2", "--timeout", "60"]


### PR DESCRIPTION
## Summary
- update the Docker entrypoint to use an absolute path so the startup script is found when containers start from docker-compose

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d27ce60d7883308e2ef580bcc3036f