### PR TITLE
Fix nginx upstream resolution in Docker setup

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,11 +1,14 @@
 gzip on;
 gzip_types text/css application/javascript application/json text/plain;
 
+resolver 127.0.0.11 valid=30s ipv6=off;
+set $backend "http://web:5000";
+
 server {
     listen 80;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     location /static/ {
-        proxy_pass http://web:5000/static/;
+        proxy_pass $backend;
         expires 7d;
         add_header Cache-Control "public";
     }
@@ -16,6 +19,6 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
-        proxy_pass http://web:5000;
+        proxy_pass $backend;
     }
 }


### PR DESCRIPTION
## Summary
- add Docker DNS resolver configuration for nginx to ensure the `web` upstream can be resolved at runtime
- reuse a shared backend proxy target for both static and dynamic routes to avoid startup failures

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d27d85e0b0833098e3f30e95c16981