### PR TITLE
Fix nginx upstream configuration

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,17 +1,19 @@
 gzip on;
 gzip_types text/css application/javascript application/json text/plain;
 
-resolver 127.0.0.11 valid=30s ipv6=off;
-set $backend "http://web:5000";
-
 server {
     listen 80;
+    resolver 127.0.0.11 valid=30s ipv6=off;
+    set $backend http://web:5000;
+
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     location /static/ {
         proxy_pass $backend;
         expires 7d;
         add_header Cache-Control "public";
     }
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- move the resolver directive into the server block so it applies to the proxy locations
- define the backend upstream variable inside the server block without quotes to avoid invalid resolution errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d27ed4cdd88330a21b5f51228ce44c