### PR TITLE
Fix nginx backend resolution

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,15 +1,17 @@
 gzip on;
 gzip_types text/css application/javascript application/json text/plain;
 
+upstream watcher_backend {
+    server web:5000;
+}
+
 server {
     listen 80;
-    resolver 127.0.0.11 valid=30s ipv6=off;
-    set $backend http://web:5000;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     location /static/ {
-        proxy_pass $backend;
+        proxy_pass http://watcher_backend;
         expires 7d;
         add_header Cache-Control "public";
     }
@@ -21,6 +23,6 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-XSS-Protection "1; mode=block" always;
-        proxy_pass $backend;
+        proxy_pass http://watcher_backend;
     }
 }


### PR DESCRIPTION
## Summary
- configure an explicit `watcher_backend` upstream in Nginx so the Flask service resolves reliably inside Docker
- update the proxy configuration to route both static assets and dynamic requests through the upstream backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28046f0e88330a493e5ece6268c5c