### PR TITLE
Fix nginx upstream resolution for docker compose

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,8 +1,16 @@
 gzip on;
 gzip_types text/css application/javascript application/json text/plain;
 
+# Ensure Docker's internal DNS (127.0.0.11) is used when resolving service
+# names so Nginx does not fail during start-up if the backend container is
+# still booting. The "resolve" flag on the upstream server forces Nginx to
+# re-resolve the hostname whenever the DNS entry changes instead of caching a
+# failed lookup forever.
+resolver 127.0.0.11 ipv6=off;
+
 upstream watcher_backend {
-    server web:5000;
+    zone watcher_backend 64k;
+    server web:5000 resolve;
 }
 
 server {


### PR DESCRIPTION
## Summary
- ensure nginx resolves the Docker Compose backend service using Docker's internal DNS
- configure the upstream to re-resolve the backend hostname when it becomes available

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3d643ba488330ad129aeccf4582a4